### PR TITLE
Allocations optimisations

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -7,17 +7,17 @@ import (
 
 // Sprint wraps fmt.Sprint with emoji support
 func Sprint(a ...interface{}) string {
-	return Parse(fmt.Sprint(a...))
+	return Replace(fmt.Sprint(a...))
 }
 
 // Sprintf wraps fmt.Sprintf with emoji support
 func Sprintf(format string, a ...interface{}) string {
-	return Parse(fmt.Sprintf(format, a...))
+	return Replace(fmt.Sprintf(format, a...))
 }
 
 // Sprintln wraps fmt.Sprintln with emoji support
 func Sprintln(a ...interface{}) string {
-	return Parse(fmt.Sprintln(a...))
+	return Replace(fmt.Sprintln(a...))
 }
 
 // Print wraps fmt.Print with emoji support

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/enescakir/emoji
+module github.com/WinnerSoftLab/emoji
 
 go 1.13

--- a/internal/generator/unicode.go
+++ b/internal/generator/unicode.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	emojipkg "github.com/enescakir/emoji"
+	emojipkg "github.com/WinnerSoftLab/emoji"
 )
 
 const emojiListURL = "https://unicode.org/Public/emoji/13.0/emoji-test.txt"

--- a/map_test.go
+++ b/map_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestEmojiMap(t *testing.T) {
 	for name, code := range emojiMap {
-		got := Parse(name)
+		got := Replace(name)
 		if got != code {
 			t.Fatalf("test case %q fail: got: %v, expected: %v", name, got, code)
 		}

--- a/parser.go
+++ b/parser.go
@@ -13,27 +13,32 @@ var (
 	flagRegex = regexp.MustCompile(`^:flag-([a-zA-Z]{2}):$`)
 )
 
-type Parser struct {
+type Replacer struct {
 	matched bytes.Buffer
 }
 
-func NewParser() *Parser {
-	return &Parser{matched: bytes.Buffer{}}
+func NewReplacer() *Replacer {
+	return &Replacer{matched: bytes.Buffer{}}
 }
 
-// Parse replaces emoji aliases (:pizza:) with unicode representation.
-func (p *Parser) Parse(input string) string {
+// Replace replaces emoji aliases (:pizza:) with unicode representation.
+func (p *Replacer) Replace(input string) string {
 	p.matched.Reset()
-	return parseInternal(input, &p.matched)
+	return replaceInternal(input, &p.matched)
 }
 
-// Parse replaces emoji aliases (:pizza:) with unicode representation.
+// Replace replaces emoji aliases (:pizza:) with unicode representation.
+func Replace(input string) string {
+	return replaceInternal(input, &bytes.Buffer{})
+}
+
+// Parse is an alias for Replace
 func Parse(input string) string {
-	return parseInternal(input, &bytes.Buffer{})
+	return Replace(input)
 }
 
-// Parse replaces emoji aliases (:pizza:) with unicode representation.
-func parseInternal(input string, matched *bytes.Buffer) string {
+// replaceInternal replaces emoji aliases (:pizza:) with unicode representation.
+func replaceInternal(input string, matched *bytes.Buffer) string {
 	var output strings.Builder
 	output.Grow(len(input))
 

--- a/parser.go
+++ b/parser.go
@@ -13,9 +13,27 @@ var (
 	flagRegex = regexp.MustCompile(`^:flag-([a-zA-Z]{2}):$`)
 )
 
+type Parser struct {
+	matched bytes.Buffer
+}
+
+func NewParser() *Parser {
+	return &Parser{matched: bytes.Buffer{}}
+}
+
+// Parse replaces emoji aliases (:pizza:) with unicode representation.
+func (p *Parser) Parse(input string) string {
+	p.matched.Reset()
+	return parseInternal(input, &p.matched)
+}
+
 // Parse replaces emoji aliases (:pizza:) with unicode representation.
 func Parse(input string) string {
-	matched := &bytes.Buffer{}
+	return parseInternal(input, &bytes.Buffer{})
+}
+
+// Parse replaces emoji aliases (:pizza:) with unicode representation.
+func parseInternal(input string, matched *bytes.Buffer) string {
 	var output strings.Builder
 	output.Grow(len(input))
 

--- a/parser.go
+++ b/parser.go
@@ -17,6 +17,7 @@ var (
 func Parse(input string) string {
 	matched := &bytes.Buffer{}
 	var output strings.Builder
+	output.Grow(len(input))
 
 	for _, r := range input {
 		// when it's not `:`, it might be inner or outer of the emoji alias

--- a/parser.go
+++ b/parser.go
@@ -45,7 +45,8 @@ func Parse(input string) string {
 
 		// it's the end of the emoji alias
 		match := matched.String()
-		alias := match + ":"
+		matched.WriteByte(':')
+		alias := matched.String()
 
 		// check for emoji alias
 		if code, ok := Find(alias); ok {
@@ -59,7 +60,6 @@ func Parse(input string) string {
 		// it might be the beginning of the another emoji alias
 		matched.Reset()
 		matched.WriteRune(r)
-
 	}
 
 	// if matched not empty, add it to output

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestParse(t *testing.T) {
+func TestReplace(t *testing.T) {
 	tt := []struct {
 		input    string
 		expected string
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
-			got := Parse(tc.input)
+			got := Replace(tc.input)
 
 			if got != tc.expected {
 				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
@@ -162,20 +162,22 @@ func TestFind(t *testing.T) {
 	}
 }
 
-func BenchmarkParse(b *testing.B) {
+func BenchmarkReplace(b *testing.B) {
+	const message = "I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:"
+
 	b.Run("static", func(b *testing.B) {
 		b.ReportAllocs()
 
 		for n := 0; n < b.N; n++ {
-			_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+			_ = Replace(message)
 		}
 	})
 
 	b.Run("reusable", func(b *testing.B) {
 		b.ReportAllocs()
-		p := NewParser()
+		p := NewReplacer()
 		for n := 0; n < b.N; n++ {
-			_ = p.Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+			_ = p.Replace(message)
 		}
 	})
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -163,9 +163,19 @@ func TestFind(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
-	b.ReportAllocs()
+	b.Run("static", func(b *testing.B) {
+		b.ReportAllocs()
 
-	for n := 0; n < b.N; n++ {
-		_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
-	}
+		for n := 0; n < b.N; n++ {
+			_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+		}
+	})
+
+	b.Run("reusable", func(b *testing.B) {
+		b.ReportAllocs()
+		p := NewParser()
+		for n := 0; n < b.N; n++ {
+			_ = p.Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+		}
+	})
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -69,10 +69,13 @@ func TestParse(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		got := Parse(tc.input)
-		if got != tc.expected {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
-		}
+		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
+			got := Parse(tc.input)
+
+			if got != tc.expected {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
+			}
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestFind(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		got, exist := Find(tc.input)
-		if got != tc.expected {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
-		}
+		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
+			got, exist := Find(tc.input)
+			if got != tc.expected {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
+			}
 
-		if exist != tc.exist {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, exist, tc.exist)
-		}
+			if exist != tc.exist {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, exist, tc.exist)
+			}
+		})
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -158,6 +158,8 @@ func TestFind(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
+	b.ReportAllocs()
+
 	for n := 0; n < b.N; n++ {
 		_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
 	}


### PR DESCRIPTION
A set of optimisations related to allocations

```
Original
BenchmarkParse
BenchmarkParse-12    	 1446430	       799.4 ns/op	     288 B/op	      14 allocs/op

Remove redundant allocation
BenchmarkParse
BenchmarkParse-12    	 1482784	       719.3 ns/op	     256 B/op	      12 allocs/op

Use bytes.Buffer for matched
BenchmarkParse
BenchmarkParse-12    	 1745038	       638.7 ns/op	     184 B/op	       5 allocs/op

Preallocate required space
BenchmarkParse/static
BenchmarkParse/static-12         	 2146411	       536.6 ns/op	     144 B/op	       2 allocs/op

Reusable parser
BenchmarkParse/reusable
BenchmarkParse/reusable-12       	 2438487	       494.8 ns/op	      80 B/op	       1 allocs/op
```